### PR TITLE
Update 01-installing-opencv-for-java.rst to include .dylib and intellij instruction

### DIFF
--- a/docs/source/01-installing-opencv-for-java.rst
+++ b/docs/source/01-installing-opencv-for-java.rst
@@ -69,3 +69,7 @@ After adding the jar, extend it, select ``Native library location`` and press ``
 .. image:: _static/01 - 03.png
 
 Select ``External Folder...`` and browse to select the folder containing the OpenCV libraries (e.g., ``C:\opencv\build\java\x64`` under Windows).
+In case of OSX, create a soft link with .dylib extension for the .so file.
+``ln -s libopencv_java300.so libopencv_java300.dylib``
+
+And if you are using IntelliJ, you can specify the location of the library with th VM argument ``-Djava.library.path=/opencv/build/lib``.


### PR DESCRIPTION
Added additional instruction for Mac OS. Need a .dylib link to the .so file. And a specific instruction for IntelliJ to include the library.